### PR TITLE
make `collection-paths` in `raco test -c` handle `.` and `..` correctly

### DIFF
--- a/compiler-lib/compiler/commands/test.rkt
+++ b/compiler-lib/compiler/commands/test.rkt
@@ -622,7 +622,11 @@
 (module paths racket/base
   (require setup/link
            racket/match
+           setup/collection-name
+           raco/command-name
            racket/list)
+
+  (define test-exe-name (string->symbol (short-program+command-name)))
 
   (struct col (name path) #:transparent)
 
@@ -666,9 +670,9 @@
   ;; This should be in Racket somewhere and return all the collection
   ;; paths, rather than just the first as collection-path does.
   (define (collection-paths c)
-    (define (path->string* maybe-path)
-      (path->string (build-path maybe-path)))
-    (match-define (list-rest sc more) (map path->string* (explode-path c)))
+    (when (not (collection-name? c))
+      (error test-exe-name "not a collection name in: ~a" c))
+    (match-define (list-rest sc more) (map path->string (explode-path c)))
     (append*
      (for/list ([col (all-collections)]
                 #:when (string=? sc (col-name col)))

--- a/compiler-lib/compiler/commands/test.rkt
+++ b/compiler-lib/compiler/commands/test.rkt
@@ -670,7 +670,7 @@
       (match maybe-path
         ['up ".."]
         ['same "."]
-        [path (write path) (path->string path)]))
+        [path (path->string path)]))
 
     (match-define (list-rest sc more) (map path->string* (explode-path c)))
     (append*

--- a/compiler-lib/compiler/commands/test.rkt
+++ b/compiler-lib/compiler/commands/test.rkt
@@ -666,7 +666,13 @@
   ;; This should be in Racket somewhere and return all the collection
   ;; paths, rather than just the first as collection-path does.
   (define (collection-paths c)
-    (match-define (list-rest sc more) (map path->string (explode-path c)))
+    (define (path->string* maybe-path)
+      (match maybe-path
+        ['up ".."]
+        ['same "."]
+        [path (write path) (path->string path)]))
+
+    (match-define (list-rest sc more) (map path->string* (explode-path c)))
     (append*
      (for/list ([col (all-collections)]
                 #:when (string=? sc (col-name col)))

--- a/compiler-lib/compiler/commands/test.rkt
+++ b/compiler-lib/compiler/commands/test.rkt
@@ -667,11 +667,7 @@
   ;; paths, rather than just the first as collection-path does.
   (define (collection-paths c)
     (define (path->string* maybe-path)
-      (match maybe-path
-        ['up ".."]
-        ['same "."]
-        [path (path->string path)]))
-
+      (path->string (build-path maybe-path)))
     (match-define (list-rest sc more) (map path->string* (explode-path c)))
     (append*
      (for/list ([col (all-collections)]

--- a/compiler-test/info.rkt
+++ b/compiler-test/info.rkt
@@ -9,6 +9,7 @@
 (define pkg-authors '(mflatt))
 (define build-deps '("compiler-lib"
                      "eli-tester"
+                     "rackunit-lib"
                      "net-lib"
                      "scheme-lib"
                      "compatibility-lib"

--- a/compiler-test/tests/compiler/commands/test.rkt
+++ b/compiler-test/tests/compiler/commands/test.rkt
@@ -2,4 +2,4 @@
 (require rackunit)
 (require (only-in (submod compiler/commands/test paths) collection-paths))
 
-(check-equal? (collection-paths ".") null)
+(check-exn exn? (lambda () (collection-paths ".")))

--- a/compiler-test/tests/compiler/commands/test.rkt
+++ b/compiler-test/tests/compiler/commands/test.rkt
@@ -1,0 +1,5 @@
+#lang racket
+(require rackunit)
+(require (only-in (submod compiler/commands/test paths) collection-paths))
+
+(check-equal? (collection-paths ".") null)


### PR DESCRIPTION
Currently this happens:

```
[master][pixels:compiler/compiler-lib] raco test -c .
path->string: contract violation
  expected: path?
  given: 'same
  context...:
   /Applications/Racket/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt:667:2: collection-paths
   /Applications/Racket/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt:1010:24: unpack322
   /Applications/Racket/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt:418:0: map/parallel43
   /Applications/Racket/racket/share/pkgs/compiler-lib/compiler/commands/test.rkt: [running body]
   /Applications/Racket/racket/collects/raco/raco.rkt: [running body]
   /Applications/Racket/racket/collects/raco/main.rkt: [running body]
```

This changes the error to:

```
[raco-test-error][pixels:extra-pkgs/compiler] raco test -c .
raco test: collection not found
  collection name: .
  context...:
   /Applications/Racket/extra-pkgs/compiler/compiler-lib/compiler/commands/test.rkt:419:0: map/parallel43
   /Applications/Racket/extra-pkgs/compiler/compiler-lib/compiler/commands/test.rkt: [running body]
   /Applications/Racket/racket/collects/raco/raco.rkt: [running body]
   /Applications/Racket/racket/collects/raco/main.rkt: [running body]
```
