### PR TITLE
Fix display missing errors on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
 - echo $PKG
 - curl -L -o installer.sh http://plt.eecs.northwestern.edu/snapshots/current/installers/min-racket-current-x86_64-linux-precise.sh
 - sh installer.sh --in-place --dest ~/racket/
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
 
 install:
 - racket -l- pkg/dirs-catalog --link --check-metadata pkgs-catalog .


### PR DESCRIPTION
because some tests `(require mred)` the tests error with:

```
Gtk initialization failed for display ":0"
  context...:
   /home/travis/racket/share/pkgs/gui-lib/mred/private/wx/gtk/queue.rkt: [running body]
   /home/travis/racket/share/pkgs/gui-lib/mred/private/wx/gtk/init.rkt: [traversing imports]
   /home/travis/racket/share/pkgs/gui-lib/mred/private/mred.rkt: [traversing imports]
```

The travis docs claim that the travis containers have `xvfb`, so lets try that...
(stolen from http://docs.travis-ci.com/user/gui-and-headless-browsers/)
